### PR TITLE
Allow feed config to influence collection processing

### DIFF
--- a/feed.php
+++ b/feed.php
@@ -81,6 +81,9 @@ class FeedPlugin extends Plugin
         if (isset($page->header()->feed)) {
             $this->feed_config = array_merge($this->feed_config, $page->header()->feed);
         }
+
+        // Overwrite regular content with feed config, so you can influence the collection processing with feed config
+        $page->header()->content = array_merge($page->header()->content, $this->feed_config);
     }
 
     /**

--- a/feed.php
+++ b/feed.php
@@ -64,7 +64,6 @@ class FeedPlugin extends Plugin
 
             $this->enable([
                 'onPageInitialized' => ['onPageInitialized', 0],
-                'onCollectionProcessed' => ['onCollectionProcessed', 0],
                 'onTwigTemplatePaths' => ['onTwigTemplatePaths', 0],
                 'onTwigSiteVariables' => ['onTwigSiteVariables', 0]
             ]);
@@ -84,18 +83,6 @@ class FeedPlugin extends Plugin
 
         // Overwrite regular content with feed config, so you can influence the collection processing with feed config
         $page->header()->content = array_merge($page->header()->content, $this->feed_config);
-    }
-
-    /**
-     * Feed consists of all sub-pages.
-     *
-     * @param Event $event
-     */
-    public function onCollectionProcessed(Event $event)
-    {
-        /** @var Collection $collection */
-        $collection = $event['collection'];
-        $collection->setParams(array_merge($collection->params(), $this->feed_config));
     }
 
     /**


### PR DESCRIPTION
This allows you to set the order for your feed to a different order than you'd have on your site. Or even select an entirely different collection by taxonomy or some such.