### PR TITLE
Prevent 500 error on non-compatible pages

### DIFF
--- a/feed.php
+++ b/feed.php
@@ -83,7 +83,9 @@ class FeedPlugin extends Plugin
         }
 
         // Overwrite regular content with feed config, so you can influence the collection processing with feed config
-        $page->header()->content = array_merge($page->header()->content, $this->feed_config);
+        if (property_exists($page->header(), 'content')) {
+            $page->header()->content = array_merge($page->header()->content, $this->feed_config);
+        }    
     }
 
     /**


### PR DESCRIPTION
The problem with this plugin is that it throws an error on any non-modular page. If one of those pages gets linked to, or somehow publicly accessible (which indeed happened to us), they produce crawl errors and related. I could see one option being to redirect to a 404 page instead of it being a 500 error response.

To avoid the 500 error, this simply checks the header to see if the `content` property has been set before obtaining the property.

I noticed that the original problem was reported in #10. This would patch that.