### PR TITLE
Change item source from summary to whole content (before truncating)

### DIFF
--- a/templates/feed.atom.twig
+++ b/templates/feed.atom.twig
@@ -25,7 +25,7 @@
             {% if banner %}
             {{ banner.cropZoom(600,400).html|raw }}
             {% endif %}
-            {{ item.summary|truncate_html(collection.params.length)|raw }}
+            {{ item.content|truncate_html(collection.params.length)|raw }}
             ]]>
         </content>
     </entry>

--- a/templates/feed.rss.twig
+++ b/templates/feed.rss.twig
@@ -17,7 +17,7 @@
                 {% if banner %}
                 {{ banner.cropZoom(600,400).html|absolute_url|raw }}
                 {% endif %}
-                {{ item.summary|truncate_html(collection.params.length)|raw }}
+                {{ item.content|truncate_html(collection.params.length)|raw }}
                 ]]>
             </description>
             <category>{{ item.taxonomy.tag|join(',') }}</category>


### PR DESCRIPTION
Solves issue #15: think in order to support untruncated feeds the item source should be the whole unsummarized post before being truncated according to length parameter.