### PR TITLE
Escape special XML characters in categories in Atom feed

### DIFF
--- a/templates/feed.atom.twig
+++ b/templates/feed.atom.twig
@@ -18,7 +18,7 @@
         <published>{{ item.date|date("Y-m-d\\TH:i:sP") }}</published>
         <link href="{{ item.url(true) }}"/>
         {% for tag in item.taxonomy.tag %}
-        <category term="{{ tag|lower }}" label="{{ tag|capitalize }}" />
+        <category term="{{ tag|lower|e }}" label="{{ tag|capitalize|e }}" />
         {% endfor %}
         <content type="html">
             <![CDATA[


### PR DESCRIPTION
Resolves: https://github.com/getgrav/grav-plugin-feed/issues/33