### PR TITLE
Always show route in url for self-link

### DIFF
--- a/templates/feed.atom.twig
+++ b/templates/feed.atom.twig
@@ -2,7 +2,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
     <title>{{ page.title }}</title>
-    <link href="{{ page.url(true) }}.{{ uri.extension() }}" rel="self" />
+    <link href="{{ uri.rootUrl(true) }}{{ uri.route() }}.{{ uri.extension() }}" rel="self" />
     <subtitle>{{ collection.params.description }}</subtitle>
     <updated>{{ collection|first.date|date("Y-m-d\\TH:i:sP") }}</updated>
     <author>

--- a/templates/feed.rss.twig
+++ b/templates/feed.rss.twig
@@ -3,7 +3,7 @@
 <rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
     <channel>
         <title>{{ page.title }}</title>
-        <link>{{ page.url(true) }}.{{ uri.extension() }}</link>
+        <link>{{ uri.rootUrl(true) }}{{ uri.route() }}.{{ uri.extension() }}</link>
         <description>{{ collection.params.description }}</description>
         <language>{{ collection.params.lang }}</language>
         <atom:link href="{{ uri.url(true) }}.{{  uri.extension }}" rel="self" type="application/rss+xml"/>


### PR DESCRIPTION
This makes the feed-link compatible with the `hide_in_urls` page option.

Fixes #11