### PR TITLE
Use safe_truncate_html instead of truncate_html for content

### DIFF
--- a/templates/feed.atom.twig
+++ b/templates/feed.atom.twig
@@ -25,7 +25,7 @@
             {% if banner %}
             {{ banner.cropZoom(600,400).html|raw }}
             {% endif %}
-            {{ item.content|truncate_html(collection.params.length)|raw }}
+            {{ item.content|safe_truncate_html(collection.params.length)|raw }}
             ]]>
         </content>
     </entry>

--- a/templates/feed.rss.twig
+++ b/templates/feed.rss.twig
@@ -17,7 +17,7 @@
                 {% if banner %}
                 {{ banner.cropZoom(600,400).html|absolute_url|raw }}
                 {% endif %}
-                {{ item.content|truncate_html(collection.params.length)|raw }}
+                {{ item.content|safe_truncate_html(collection.params.length)|raw }}
                 ]]>
             </description>
             <category>{{ item.taxonomy.tag|join(',') }}</category>


### PR DESCRIPTION
Even if mb_substr() is used to truncate, for some odd reason it failed on
non-ascii caracters and broke rss validity. 🤔

Anyway, this makes sure it's properly truncated and it's better for the
end user anyway.