### PR TITLE
Use Grav current language rather than lang setting 

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ The first line adds the **Atom** feed by simply adding `.atom` to the base URL o
 enable_json_feed: false
 limit: 10
 description: My Feed Description
-lang: en-us
 length: 500
 ```
 

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -43,6 +43,7 @@ form:
     lang:
       type: text
       label: Feed language code
+      help: Ignored when LangSwitcher plugin is enabled
       default: en
       placeholder: en
       validate:

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -40,15 +40,6 @@ form:
       type: textarea
       label: Description
 
-    lang:
-      type: text
-      label: Feed language code
-      help: Ignored when LangSwitcher plugin is enabled
-      default: en
-      placeholder: en
-      validate:
-        pattern: "[a-zA-Z]{2,3}(-[a-zA-Z]{2,3})?"
-
     length:
       type: range
       label: Feed Length (0 for full-text feed)

--- a/feed.yaml
+++ b/feed.yaml
@@ -1,6 +1,5 @@
 enabled: true
 limit: 10
 description: 'My Feed Description'
-lang: en-us
 length: 500
 enable_json_feed: false

--- a/templates/feed.rss.twig
+++ b/templates/feed.rss.twig
@@ -5,11 +5,7 @@
         <title>{{ page.title }}</title>
         <link>{{ uri.rootUrl(true) }}{{ uri.route() }}.{{ uri.extension() }}</link>
         <description>{{ collection.params.description }}</description>
-        {% if config.plugins.langswitcher.enabled %}
-        <language>{{ langswitcher.current }}</language>
-        {% else %}
-        <language>{{ collection.params.lang }}</language>
-        {% endif %}
+        <language>{{ grav.language.getLanguage }}</language>
         <atom:link href="{{ uri.url(true) }}.{{  uri.extension }}" rel="self" type="application/rss+xml"/>
         {% for item in collection %}
         {% set banner = item.media.images|first %}

--- a/templates/feed.rss.twig
+++ b/templates/feed.rss.twig
@@ -5,7 +5,11 @@
         <title>{{ page.title }}</title>
         <link>{{ uri.rootUrl(true) }}{{ uri.route() }}.{{ uri.extension() }}</link>
         <description>{{ collection.params.description }}</description>
+        {% if config.plugins.langswitcher.enabled %}
+        <language>{{ langswitcher.current }}</language>
+        {% else %}
         <language>{{ collection.params.lang }}</language>
+        {% endif %}
         <atom:link href="{{ uri.url(true) }}.{{  uri.extension }}" rel="self" type="application/rss+xml"/>
         {% for item in collection %}
         {% set banner = item.media.images|first %}


### PR DESCRIPTION
If [LangSwitcher](https://github.com/getgrav/grav-plugin-langswitcher) is enabled, use current language provided by LangSwitcher as RSS feed language code, superseding lang code from Feed plugin settings.