### PR TITLE
Plugin overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ The first line adds the **Atom** feed by simply adding `.atom` to the base URL o
 enable_json_feed: false
 limit: 10
 description: My Feed Description
-lang: en-us
 length: 500
 ```
 

--- a/README.md
+++ b/README.md
@@ -76,10 +76,11 @@ The first line adds the **Atom** feed by simply adding `.atom` to the base URL o
 # Config Defaults
 
 ```
-enable_json_feed: false
+enabled: true
 limit: 10
-description: My Feed Description
+description: 'My Feed Description'
 length: 500
+enable_json_feed: false
 ```
 
 You can override any of the default values by setting one or more of these in your blog list page where `sub_pages` is defined. For example:

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ title: 'My Feed Title'
 description: 'My Feed Description'
 length: 500
 enable_json_feed: false
+show_last_modified: false
 ```
 
 You can override any of the default values by setting one or more of these in your blog list page where `sub_pages` is defined. For example:

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The first line adds the **Atom** feed by simply adding `.atom` to the base URL o
 ```
 enabled: true
 limit: 10
+title: 'My Feed Title'
 description: 'My Feed Description'
 length: 500
 enable_json_feed: false

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -43,6 +43,7 @@ form:
     lang:
       type: text
       label: Feed language code
+      help: Ignored when LangSwitcher plugin is enabled
       default: en
       placeholder: en
       validate:

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -36,6 +36,10 @@ form:
         min: 10
         max: 1000
 
+    title:
+      type: text
+      label: Title
+
     description:
       type: textarea
       label: Description

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -40,15 +40,6 @@ form:
       type: textarea
       label: Description
 
-    lang:
-      type: text
-      label: Feed language code
-      help: Ignored when LangSwitcher plugin is enabled
-      default: en
-      placeholder: en
-      validate:
-        pattern: "[a-zA-Z]{2,3}(-[a-zA-Z]{2,3})?"
-
     length:
       type: range
       label: Feed Length (0 for full-text feed)

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -62,3 +62,15 @@ form:
         0: Disabled
       validate:
         type: bool
+
+    show_last_modified:
+      type: toggle
+      label: Show last modified date
+      help: If enabled, file modification date will be used for computing "last updated" times in feeds
+      highlight: 0
+      default: 0
+      options:
+        1: Enabled
+        0: Disabled
+      validate:
+        type: bool

--- a/blueprints/feed.yaml
+++ b/blueprints/feed.yaml
@@ -13,6 +13,10 @@ form:
               validate:
                 type: int
 
+            header.feed.title:
+              type: text
+              label: Feed title
+
             header.feed.description:
               type: text
               label: Feed description

--- a/feed.yaml
+++ b/feed.yaml
@@ -1,5 +1,6 @@
 enabled: true
 limit: 10
+title: 'My Feed Title'
 description: 'My Feed Description'
 length: 500
 enable_json_feed: false

--- a/feed.yaml
+++ b/feed.yaml
@@ -1,6 +1,5 @@
 enabled: true
 limit: 10
 description: 'My Feed Description'
-lang: en-us
 length: 500
 enable_json_feed: false

--- a/feed.yaml
+++ b/feed.yaml
@@ -4,3 +4,4 @@ title: 'My Feed Title'
 description: 'My Feed Description'
 length: 500
 enable_json_feed: false
+show_last_modified: false

--- a/templates/feed.atom.twig
+++ b/templates/feed.atom.twig
@@ -14,7 +14,7 @@
     <subtitle>{{ collection.params.description }}</subtitle>
     <updated>{{ feed_updated|date("Y-m-d\\TH:i:sP") }}</updated>
     <author>
-        <name>{{ site.author.name|default("Grav User") }}</name>
+        <name>{{ site.author.name }}</name>
     </author>
     <id>{{ page.url(true) }}</id>
     {% for item in collection %}

--- a/templates/feed.atom.twig
+++ b/templates/feed.atom.twig
@@ -1,3 +1,4 @@
+{# Format specification: https://tools.ietf.org/html/rfc4287 #}
 {% set collection = collection|default(page.collection) %}
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">

--- a/templates/feed.atom.twig
+++ b/templates/feed.atom.twig
@@ -16,7 +16,7 @@
     <author>
         <name>{{ site.author.name|default("Grav User") }}</name>
     </author>
-    <id>{{ uri.rootUrl(true) }}{{ uri.route() }}</id>
+    <id>{{ page.url(true) }}</id>
     {% for item in collection %}
     {% set banner = item.media.images|first %}
     <entry>

--- a/templates/feed.atom.twig
+++ b/templates/feed.atom.twig
@@ -10,7 +10,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
     <title>{{ collection.params.title }}</title>
-    <link href="{{ uri.rootUrl(true) }}{{ uri.route() }}.{{ uri.extension() }}" rel="self" />
+    <link href="{{ uri.rootUrl(true)~uri.uri() }}" rel="self" />
     <subtitle>{{ collection.params.description }}</subtitle>
     <updated>{{ feed_updated|date("Y-m-d\\TH:i:sP") }}</updated>
     <author>

--- a/templates/feed.atom.twig
+++ b/templates/feed.atom.twig
@@ -1,11 +1,18 @@
 {# Format specification: https://tools.ietf.org/html/rfc4287 #}
 {% set collection = collection|default(page.collection) %}
+{% set feed_updated = 0 %}
+{% for page in collection %}
+    {% set feed_updated = max(feed_updated, page.date) %}
+    {% if collection.params.show_last_modified %}
+        {% set feed_updated = max(feed_updated, page.modified) %}
+    {% endif %}
+{% endfor %}
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
     <title>{{ page.title }}</title>
     <link href="{{ uri.rootUrl(true) }}{{ uri.route() }}.{{ uri.extension() }}" rel="self" />
     <subtitle>{{ collection.params.description }}</subtitle>
-    <updated>{{ collection|first.date|date("Y-m-d\\TH:i:sP") }}</updated>
+    <updated>{{ feed_updated|date("Y-m-d\\TH:i:sP") }}</updated>
     <author>
         <name>{{ site.author.name|default("Grav User") }}</name>
     </author>

--- a/templates/feed.atom.twig
+++ b/templates/feed.atom.twig
@@ -30,7 +30,7 @@
         <published>{{ item.date|date("Y-m-d\\TH:i:sP") }}</published>
         <link href="{{ item.url(true) }}"/>
         {% for tag in item.taxonomy.tag %}
-        <category term="{{ tag|lower|e }}" label="{{ tag|capitalize|e }}" />
+        <category term="{{ tag|e }}" />
         {% endfor %}
         <content type="html">
             <![CDATA[

--- a/templates/feed.atom.twig
+++ b/templates/feed.atom.twig
@@ -9,7 +9,7 @@
 {% endfor %}
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
-    <title>{{ page.title }}</title>
+    <title>{{ collection.params.title }}</title>
     <link href="{{ uri.rootUrl(true) }}{{ uri.route() }}.{{ uri.extension() }}" rel="self" />
     <subtitle>{{ collection.params.description }}</subtitle>
     <updated>{{ feed_updated|date("Y-m-d\\TH:i:sP") }}</updated>

--- a/templates/feed.atom.twig
+++ b/templates/feed.atom.twig
@@ -22,7 +22,11 @@
     <entry>
         <title>{{ item.title|e }}</title>
         <id>{{ item.url(true) }}</id>
+        {% if collection.params.show_last_modified %}
+        <updated>{{ item.modified|date("Y-m-d\\TH:i:sP") }}</updated>
+        {% else %}
         <updated>{{ item.date|date("Y-m-d\\TH:i:sP") }}</updated>
+        {% endif %}
         <published>{{ item.date|date("Y-m-d\\TH:i:sP") }}</published>
         <link href="{{ item.url(true) }}"/>
         {% for tag in item.taxonomy.tag %}

--- a/templates/feed.atom.twig
+++ b/templates/feed.atom.twig
@@ -2,10 +2,10 @@
 {% set collection = collection|default(page.collection) %}
 {% set feed_updated = 0 %}
 {% for page in collection %}
-    {% set feed_updated = max(feed_updated, page.date) %}
-    {% if collection.params.show_last_modified %}
-        {% set feed_updated = max(feed_updated, page.modified) %}
-    {% endif %}
+    {%- set feed_updated = max(feed_updated, page.date) %}
+    {%- if collection.params.show_last_modified %}
+        {%- set feed_updated = max(feed_updated, page.modified) %}
+    {%- endif %}
 {% endfor %}
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">

--- a/templates/feed.json.twig
+++ b/templates/feed.json.twig
@@ -1,17 +1,25 @@
 {# Format specification: https://www.jsonfeed.org/version/1/ #}
 {% set collection = collection|default(page.collection) %}
-{% set jsonfeed = {"version" : "https://jsonfeed.org/version/1", "title" :collection.params.title , "home_page_url" :  page.url(true), "feed_url" : uri.rootUrl(true)~uri.uri()} %}
-{% set jsonfeed = jsonfeed|merge({"author" : {"url"  : "link to your social media", "name"  : site.author.name} }) %}
+{% set jsonfeed = {
+    "version" : "https://jsonfeed.org/version/1",
+    "title": collection.params.title,
+    "home_page_url": page.url(true),
+    "feed_url": uri.rootUrl(true)~uri.uri(),
+    "description": collection.params.description,
+    "author": {"name": site.author.name}
+} %}
+
 {% set itemList = [] %}
 {% for item in collection %}
-	{% set banner = item.media.images|first %}
-	{%- set post = {"title": item.title|e } %}
-    {%- set post = post|merge({"date_published": item.date|date('Y-m-d\\TH:i:sP') }) %}
-    {%- set post = post|merge({"date_modified": item.date|date('Y-m-d\\TH:i:sP') }) %}
-    {%- set post = post|merge({"id": item.url(true) }) %}
-    {%- set post = post|merge({"url": item.url(true) }) %}
-    {%- set post = post|merge({"author": {"name" : site.author.name}}) %}
-    {%- set post = post|merge({"content_html": item.content|safe_truncate_html(collection.params.length) }) %}
+    {%- set post = {
+        "title": item.title|e,
+        "date_published": item.date|date('Y-m-d\\TH:i:sP'),
+        "id": item.url(true),
+        "url": item.url(true),
+        "content_html": item.content|safe_truncate_html(collection.params.length)
+    } %}
+    {% set banner = item.media.images|first %}
+
 		{%- set post = post|merge({"post_image": banner.url(true) }) %}
     {%- set itemList = itemList|merge([post]) %}
 {% endfor %}

--- a/templates/feed.json.twig
+++ b/templates/feed.json.twig
@@ -1,6 +1,6 @@
 {# Format specification: https://www.jsonfeed.org/version/1/ #}
 {% set collection = collection|default(page.collection) %}
-{% set jsonfeed = {"version" : "https://jsonfeed.org/version/1", "title" :page.title , "home_page_url" :  page.url(true), "feed_url" : "http://www.yoursiteurl.com/blog"} %}
+{% set jsonfeed = {"version" : "https://jsonfeed.org/version/1", "title" :collection.params.title , "home_page_url" :  page.url(true), "feed_url" : "http://www.yoursiteurl.com/blog"} %}
 {% set jsonfeed = jsonfeed|merge({"author" : {"url"  : "link to your social media", "name"  : site.author.name} }) %}
 {% set itemList = [] %}
 {% for item in collection %}

--- a/templates/feed.json.twig
+++ b/templates/feed.json.twig
@@ -11,7 +11,7 @@
     {%- set post = post|merge({"id": item.url(true) }) %}
     {%- set post = post|merge({"url": item.url(true) }) %}
     {%- set post = post|merge({"author": {"name" : site.author.name}}) %}
-    {%- set post = post|merge({"content_html": item.content }) %}
+    {%- set post = post|merge({"content_html": item.content|safe_truncate_html(collection.params.length) }) %}
 		{%- set post = post|merge({"post_image": banner.url(true) }) %}
     {%- set itemList = itemList|merge([post]) %}
 {% endfor %}

--- a/templates/feed.json.twig
+++ b/templates/feed.json.twig
@@ -20,11 +20,24 @@
     } %}
     {% set banner = item.media.images|first %}
 
+    {% if item.header.metadata.description %}
+        {%- set post = post|merge({"summary": item.header.metadata.description|e}) %}
+    {% endif %}
+
+    {% if collection.params.show_last_modified %}
+        {%- set post = post|merge({"date_modified": item.modified|date('Y-m-d\\TH:i:sP')}) %}
+    {% endif %}
+
+    {% if item.taxonomy.tag %}
+        {%- set post = post|merge({"tags": item.taxonomy.tag}) %}
+    {% endif %}
+
     {% set image = item.media.images|first %}
     {% if image %}
         {%- set post = post|merge({"image": image.url(true)}) %}
     {% endif %}
     {%- set itemList = itemList|merge([post]) %}
 {% endfor %}
+
 {% set jsonfeed = jsonfeed|merge({"items": itemList}) %}
 {{- jsonfeed|json_encode }}

--- a/templates/feed.json.twig
+++ b/templates/feed.json.twig
@@ -1,3 +1,4 @@
+{# Format specification: https://www.jsonfeed.org/version/1/ #}
 {% set collection = collection|default(page.collection) %}
 {% set jsonfeed = {"version" : "https://jsonfeed.org/version/1", "title" :page.title , "home_page_url" :  page.url(true), "feed_url" : "http://www.yoursiteurl.com/blog"} %}
 {% set jsonfeed = jsonfeed|merge({"author" : {"url"  : "link to your social media", "name"  : site.author.name} }) %}

--- a/templates/feed.json.twig
+++ b/templates/feed.json.twig
@@ -6,8 +6,8 @@
 {% for item in collection %}
 	{% set banner = item.media.images|first %}
 	{%- set post = {"title": item.title|e } %}
-    {%- set post = post|merge({"date_published": item.date|date('Y-m-d') }) %}
-    {%- set post = post|merge({"date_modified": item.date|date('Y-m-d') }) %}
+    {%- set post = post|merge({"date_published": item.date|date('Y-m-d\\TH:i:sP') }) %}
+    {%- set post = post|merge({"date_modified": item.date|date('Y-m-d\\TH:i:sP') }) %}
     {%- set post = post|merge({"id": item.url(true) }) %}
     {%- set post = post|merge({"url": item.url(true) }) %}
     {%- set post = post|merge({"author": {"name" : site.author.name}}) %}

--- a/templates/feed.json.twig
+++ b/templates/feed.json.twig
@@ -1,6 +1,6 @@
 {# Format specification: https://www.jsonfeed.org/version/1/ #}
 {% set collection = collection|default(page.collection) %}
-{% set jsonfeed = {"version" : "https://jsonfeed.org/version/1", "title" :collection.params.title , "home_page_url" :  page.url(true), "feed_url" : "http://www.yoursiteurl.com/blog"} %}
+{% set jsonfeed = {"version" : "https://jsonfeed.org/version/1", "title" :collection.params.title , "home_page_url" :  page.url(true), "feed_url" : uri.rootUrl(true)~uri.uri()} %}
 {% set jsonfeed = jsonfeed|merge({"author" : {"url"  : "link to your social media", "name"  : site.author.name} }) %}
 {% set itemList = [] %}
 {% for item in collection %}

--- a/templates/feed.json.twig
+++ b/templates/feed.json.twig
@@ -20,7 +20,10 @@
     } %}
     {% set banner = item.media.images|first %}
 
-		{%- set post = post|merge({"post_image": banner.url(true) }) %}
+    {% set image = item.media.images|first %}
+    {% if image %}
+        {%- set post = post|merge({"image": image.url(true)}) %}
+    {% endif %}
     {%- set itemList = itemList|merge([post]) %}
 {% endfor %}
 {% set jsonfeed = jsonfeed|merge({"items": itemList}) %}

--- a/templates/feed.rss.twig
+++ b/templates/feed.rss.twig
@@ -5,11 +5,7 @@
         <title>{{ page.title }}</title>
         <link>{{ uri.rootUrl(true) }}{{ uri.route() }}.{{ uri.extension() }}</link>
         <description>{{ collection.params.description }}</description>
-        {% if config.plugins.langswitcher.enabled %}
-        <language>{{ langswitcher.current }}</language>
-        {% else %}
-        <language>{{ collection.params.lang }}</language>
-        {% endif %}
+        <language>{{ grav.language.getLanguage }}</language>
         <atom:link href="{{ uri.url(true) }}.{{  uri.extension }}" rel="self" type="application/rss+xml"/>
         {% for item in collection %}
         {% set banner = item.media.images|first %}

--- a/templates/feed.rss.twig
+++ b/templates/feed.rss.twig
@@ -11,7 +11,7 @@
 <rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
     <channel>
         <title>{{ collection.params.title }}</title>
-        <link>{{ uri.rootUrl(true) }}{{ uri.route() }}.{{ uri.extension() }}</link>
+        <link>{{ page.url(true) }}</link>
         <atom:link href="{{ uri.rootUrl(true)~uri.uri() }}" rel="self" type="application/rss+xml"/>
         <description>{{ collection.params.description }}</description>
         <language>{{ grav.language.getLanguage }}</language>

--- a/templates/feed.rss.twig
+++ b/templates/feed.rss.twig
@@ -10,7 +10,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
     <channel>
-        <title>{{ page.title }}</title>
+        <title>{{ collection.params.title }}</title>
         <link>{{ uri.rootUrl(true) }}{{ uri.route() }}.{{ uri.extension() }}</link>
         <description>{{ collection.params.description }}</description>
         <language>{{ grav.language.getLanguage }}</language>

--- a/templates/feed.rss.twig
+++ b/templates/feed.rss.twig
@@ -2,10 +2,10 @@
 {% set collection = collection|default(page.collection) %}
 {% set lastBuildDate = 0 %}
 {% for page in collection %}
-    {% set lastBuildDate = max(lastBuildDate, page.date) %}
-    {% if collection.params.show_last_modified %}
-        {% set lastBuildDate = max(feed_updated, page.modified) %}
-    {% endif %}
+    {%- set lastBuildDate = max(lastBuildDate, page.date) %}
+    {%- if collection.params.show_last_modified %}
+        {%- set lastBuildDate = max(feed_updated, page.modified) %}
+    {%- endif %}
 {% endfor %}
 <?xml version="1.0" encoding="utf-8"?>
 <rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">

--- a/templates/feed.rss.twig
+++ b/templates/feed.rss.twig
@@ -21,6 +21,8 @@
         <item>
             <title>{{ item.title|e }}</title>
             <link>{{ item.url(true) }}</link>
+            <guid>{{ item.url(true) }}</guid>
+            <pubDate>{{ item.date|date('D, d M Y H:i:s O') }}</pubDate>
             <description>
                 <![CDATA[
                 {% if banner %}
@@ -29,8 +31,6 @@
                 {{ item.content|safe_truncate_html(collection.params.length)|raw }}
                 ]]>
             </description>
-            <guid>{{ item.url(true) }}</guid>
-            <pubDate>{{ item.date|date('D, d M Y H:i:s O') }}</pubDate>
             {% for tag in item.taxonomy.tag %}
                 <category>{{ tag|e }}</category>
             {% endfor %}

--- a/templates/feed.rss.twig
+++ b/templates/feed.rss.twig
@@ -12,9 +12,9 @@
     <channel>
         <title>{{ collection.params.title }}</title>
         <link>{{ uri.rootUrl(true) }}{{ uri.route() }}.{{ uri.extension() }}</link>
+        <atom:link href="{{ uri.rootUrl(true)~uri.uri() }}" rel="self" type="application/rss+xml"/>
         <description>{{ collection.params.description }}</description>
         <language>{{ grav.language.getLanguage }}</language>
-        <atom:link href="{{ uri.url(true) }}.{{  uri.extension }}" rel="self" type="application/rss+xml"/>
         <lastBuildDate>{{ lastBuildDate|date('D, d M Y H:i:s O') }}</lastBuildDate>
         {% for item in collection %}
         {% set banner = item.media.images|first %}

--- a/templates/feed.rss.twig
+++ b/templates/feed.rss.twig
@@ -5,7 +5,11 @@
         <title>{{ page.title }}</title>
         <link>{{ uri.rootUrl(true) }}{{ uri.route() }}.{{ uri.extension() }}</link>
         <description>{{ collection.params.description }}</description>
+        {% if config.plugins.langswitcher.enabled %}
+        <language>{{ langswitcher.current }}</language>
+        {% else %}
         <language>{{ collection.params.lang }}</language>
+        {% endif %}
         <atom:link href="{{ uri.url(true) }}.{{  uri.extension }}" rel="self" type="application/rss+xml"/>
         {% for item in collection %}
         {% set banner = item.media.images|first %}

--- a/templates/feed.rss.twig
+++ b/templates/feed.rss.twig
@@ -1,3 +1,4 @@
+{# Format specification: https://www.rssboard.org/rss-specification #}
 {% set collection = collection|default(page.collection) %}
 <?xml version="1.0" encoding="utf-8"?>
 <rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">

--- a/templates/feed.rss.twig
+++ b/templates/feed.rss.twig
@@ -1,5 +1,12 @@
 {# Format specification: https://www.rssboard.org/rss-specification #}
 {% set collection = collection|default(page.collection) %}
+{% set lastBuildDate = 0 %}
+{% for page in collection %}
+    {% set lastBuildDate = max(lastBuildDate, page.date) %}
+    {% if collection.params.show_last_modified %}
+        {% set lastBuildDate = max(feed_updated, page.modified) %}
+    {% endif %}
+{% endfor %}
 <?xml version="1.0" encoding="utf-8"?>
 <rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
     <channel>
@@ -8,6 +15,7 @@
         <description>{{ collection.params.description }}</description>
         <language>{{ grav.language.getLanguage }}</language>
         <atom:link href="{{ uri.url(true) }}.{{  uri.extension }}" rel="self" type="application/rss+xml"/>
+        <lastBuildDate>{{ lastBuildDate|date('D, d M Y H:i:s O') }}</lastBuildDate>
         {% for item in collection %}
         {% set banner = item.media.images|first %}
         <item>

--- a/templates/feed.rss.twig
+++ b/templates/feed.rss.twig
@@ -29,9 +29,11 @@
                 {{ item.content|safe_truncate_html(collection.params.length)|raw }}
                 ]]>
             </description>
-            <category>{{ item.taxonomy.tag|join(',') }}</category>
             <guid>{{ item.url(true) }}</guid>
             <pubDate>{{ item.date|date('D, d M Y H:i:s O') }}</pubDate>
+            {% for tag in item.taxonomy.tag %}
+                <category>{{ tag|e }}</category>
+            {% endfor %}
         </item>
         {% endfor %}
     </channel>


### PR DESCRIPTION
- New `title` parameter (fixes #49).
- New `show_last_modified_parameter`. If enabled, file modification date will be used for computing "last updated" times in feeds.
- Fix feed link and feed origin page backlink for all feeds.
- Small improvements to RSS feeds (`lastBuildDate`, tags, automatic language detection).
- Small improvements to Atom feeds (`updated` calculations).
- Overhaul of JSON feeds (add some optional fields, fix date formats, content truncation, image, and fixes #55).