### PR TITLE
Allow template overrides based on header feed config

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,17 @@ Manually updating Feed is pretty simple. Here is what you will need to do to get
 
 > Note: Any changes you have made to any of the files listed under this directory will also be removed and replaced by the new set. Any files located elsewhere (for example a YAML settings file placed in `user/config/plugins`) will remain intact.
 
+## Overriding the default feed template:
+
+Sometimes, you may wish to use a different template for an RSS/ ATOM/ JSON feed.  To override a feed's template, place the following in the page header:
+``` yaml
+feed:
+    template:
+        rss: my-override
+```
+
+Create the `my-override.rss.twig` in your theme/ plugin's `templates` folder and add it to your [twig template paths](https://learn.getgrav.org/17/cookbook/plugin-recipes#custom-twig-templates-plu).  Change `*.rss.*` to `*.atom.*` or `*.json.*` to override those page types.
+
 ## Nginx Note:
 
 If you are having trouble with 404s with Nginx, it might be related to your configuration. You may need to remove the feed extensions from the list of types to cache as static files: `.xml`, `.rss`, and `.atom`. For example:

--- a/feed.php
+++ b/feed.php
@@ -77,7 +77,6 @@ class FeedPlugin extends Plugin
         $this->type = $uri->extension();
 
         if ($this->type && in_array($this->type, $this->valid_types)) {
-
             $this->enable([
                 'onPageInitialized' => ['onPageInitialized', 0],
                 'onTwigTemplatePaths' => ['onTwigTemplatePaths', 0],
@@ -94,19 +93,27 @@ class FeedPlugin extends Plugin
 
         // Overwrite regular content with feed config, so you can influence the collection processing with feed config
         if (property_exists($page->header(), 'content')) {
+            // Set default template.
+            $template = "feed";
+
             if (isset($page->header()->feed)) {
                 $this->feed_config = array_merge($this->feed_config, $page->header()->feed);
+
+                // Look for feed type override,
+                if (isset($this->feed_config['template']) && isset($this->feed_config['template'][$this->type])) {
+                    $template = $this->feed_config['template'][$this->type];
+                }
             }
 
             $page->header()->content = array_merge($page->header()->content, $this->feed_config);
 
-            $this->grav['twig']->template = 'feed.' . $this->type . '.twig';
+            // Set page template.
+            $this->grav['twig']->template = $template . "." . $this->type . '.twig';
 
             $this->enable([
                 'onCollectionProcessed' => ['onCollectionProcessed', 0],
             ]);
         }
-
     }
 
     /**


### PR DESCRIPTION
This PR allows a developer to override the feed.(rss|atom|json).twig feed template via a `header.feed.template.(rss|atom|json)` field.

This will not break existing overrides from other developers.  If the `header.feed.template` key doesn't exist, the feed plugin will default to its own template.

Also updated the README to describe the new functionality.