### PR TITLE
add page header link to feed item

### DIFF
--- a/templates/feed.atom.twig
+++ b/templates/feed.atom.twig
@@ -29,6 +29,9 @@
         {% endif %}
         <published>{{ item.date|date("Y-m-d\\TH:i:sP") }}</published>
         <link href="{{ item.url(true) }}"/>
+        {% if (item.header.link) %}
+        <link href="{{ item.header.link }}" rel="alternate"/>
+        {% endif %}
         {% for tag in item.taxonomy.tag %}
         <category term="{{ tag|e }}" />
         {% endfor %}

--- a/templates/feed.json.twig
+++ b/templates/feed.json.twig
@@ -36,6 +36,10 @@
     {% if image %}
         {%- set post = post|merge({"image": image.url(true)}) %}
     {% endif %}
+
+    {% if item.header.link %}
+        {%- set post = post|merge({"external_url": item.header.link}) %}
+    {% endif %}
     {%- set itemList = itemList|merge([post]) %}
 {% endfor %}
 

--- a/templates/feed.rss.twig
+++ b/templates/feed.rss.twig
@@ -21,6 +21,9 @@
         <item>
             <title>{{ item.title|e }}</title>
             <link>{{ item.url(true) }}</link>
+            {% if (item.header.link) %}
+            <link>{{ item.header.link }}</link>
+            {% endif %}
             <guid>{{ item.url(true) }}</guid>
             <pubDate>{{ item.date|date('D, d M Y H:i:s O') }}</pubDate>
             <description>


### PR DESCRIPTION
Grav allows to define an [additional link in the page header](https://demo.getgrav.org/blog-skeleton/blog/daring-fireball-link). If set, this change adds it to the feed item.