### PR TITLE
Implement implicit skip behavior

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -76,3 +76,15 @@ form:
         0: Disabled
       validate:
         type: bool
+
+    skip_behavior:
+      type: toggle
+      label: Skip behavior
+      help: "Explicit: all articles are included, use `skip: true` to exclude. Implicit: all articles are skipped, use `skip: false` to include."
+      highlight: 0
+      default: 0
+      options:
+        1: Implicit
+        0: Explicit
+      validate:
+        type: bool

--- a/feed.php
+++ b/feed.php
@@ -129,8 +129,17 @@ class FeedPlugin extends Plugin
 
         foreach ($collection as $slug => $page) {
             $header = $page->header();
-            if (isset($header->feed) && !empty($header->feed['skip'])) {
-                $collection->remove($page);
+            if ($this->feed_config['skip_behavior']) {
+                // Implicit skip: exclude all, include if skip is set to false
+                if (!isset($header->feed['skip']) || !empty($header->feed['skip'])) {
+                    $collection->remove($page);
+                }
+            }
+            else {
+                // Explicit skip (default): include all, exclude if skip is set to true
+                if (isset($header->feed) && !empty($header->feed['skip'])) {
+                    $collection->remove($page);
+                }
             }
         }
     }

--- a/feed.yaml
+++ b/feed.yaml
@@ -5,3 +5,4 @@ description: 'My Feed Description'
 length: 500
 enable_json_feed: false
 show_last_modified: false
+skip_behavior: false


### PR DESCRIPTION
By default, skipping is explicit, meaning that all pages are included in the RSS feed, unless explicitly set to be skipped. This commit allows the user to flip this behavior, so that skipping is implicit: all pages are skipped, unless set to _not_ be skipped.

This is useful for sites with many pages that do not need to be in the RSS feed, where it becomes inconvenient to add the skip frontmatter header to each page.